### PR TITLE
Fix Storage definition for the entity customslider

### DIFF
--- a/src/Entity/CustomSlider.php
+++ b/src/Entity/CustomSlider.php
@@ -14,6 +14,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *   id = "customslider",
  *   label = @Translation("Custom Slider"),
  *   base_table = "customslider",
+     data_table = "customslider_field_data",
  *   entity_keys = {
  *     "id" = "id",
  *     "label" = "name",


### PR DESCRIPTION
This pull request fix the storage definition for the entity customslider. This parameter is needed when we define a multilanguage entity.
